### PR TITLE
feat: Initial implementation of remote Kubernetes job launcher

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,36 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the requirements file into the container at /usr/src/app
+COPY requirements.txt ./
+
+# Install any needed packages specified in requirements.txt
+# Using --no-cache-dir to reduce image size
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container at /usr/src/app
+COPY main.py .
+
+# Specify the user to run the application (optional, but good practice)
+# Create a non-root user for security purposes
+RUN useradd --create-home appuser
+USER appuser
+WORKDIR /home/appuser/app # Change workdir for the new user
+COPY --chown=appuser:appuser main.py .
+# Note: requirements.txt was already installed system-wide, which is fine.
+# If main.py was also copied to /usr/src/app before USER appuser,
+# we would need to ensure appuser has access or copy it again to the new WORKDIR.
+# For simplicity here, we copy main.py again to the new WORKDIR owned by appuser.
+
+# Define environment variables if necessary (e.g., default values for args)
+# ENV NAME="World"
+
+# Run main.py when the container launches
+# The arguments will be passed to the entrypoint/cmd during Kubernetes deployment
+ENTRYPOINT ["python", "main.py"]
+
+# Example default command (can be overridden in Kubernetes manifest)
+# CMD ["--target-cluster-name", "my-eks-b", "--job-image", "busybox"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,107 @@
+import os
+import argparse
+import logging
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def launch_job_in_cluster(target_cluster_name: str, job_image: str, job_namespace: str = "default", kubeconfig_base_path: str = "/etc/kubeconfigs"):
+    """
+    Launches a Kubernetes Job in the specified target cluster.
+
+    Args:
+        target_cluster_name: The name of the target EKS cluster (used to find the kubeconfig).
+        job_image: The Docker image for the Job.
+        job_namespace: The namespace in the target cluster to launch the Job.
+        kubeconfig_base_path: The base directory where kubeconfig files are mounted.
+    """
+    kubeconfig_path = os.path.join(kubeconfig_base_path, target_cluster_name)
+
+    if not os.path.exists(kubeconfig_path):
+        logging.error(f"Kubeconfig file not found for cluster '{target_cluster_name}' at {kubeconfig_path}")
+        raise FileNotFoundError(f"Kubeconfig file not found for cluster '{target_cluster_name}' at {kubeconfig_path}")
+
+    logging.info(f"Loading kubeconfig from: {kubeconfig_path}")
+    try:
+        # Load Kubernetes configuration from the specified kubeconfig file
+        api_client = config.new_client_from_config(config_file=kubeconfig_path)
+        batch_v1 = client.BatchV1Api(api_client)
+    except Exception as e:
+        logging.error(f"Error loading kubeconfig or creating Kubernetes client: {e}")
+        raise
+
+    # Define the Job
+    job_name = f"remote-job-{target_cluster_name}-{os.getpid()}-{hash(job_image)[-6:]}"
+    logging.info(f"Defining Job: {job_name} with image: {job_image} in namespace: {job_namespace}")
+
+    container = client.V1Container(
+        name=f"{job_name}-container",
+        image=job_image,
+        command=["/bin/sh", "-c"], # Example command
+        args=["echo 'Hello from remote job!'; sleep 10; echo 'Remote job finished.'"] # Example args
+    )
+
+    template = client.V1PodTemplateSpec(
+        metadata=client.V1ObjectMeta(labels={"app": "remote-job-runner", "cluster": target_cluster_name}),
+        spec=client.V1PodSpec(restart_policy="Never", containers=[container])
+    )
+
+    job_spec = client.V1JobSpec(
+        template=template,
+        backoff_limit=4 # Number of retries before considering a Job as failed
+    )
+
+    job = client.V1Job(
+        api_version="batch/v1",
+        kind="Job",
+        metadata=client.V1ObjectMeta(name=job_name),
+        spec=job_spec
+    )
+
+    try:
+        logging.info(f"Creating Job '{job_name}' in namespace '{job_namespace}' on cluster '{target_cluster_name}'...")
+        api_response = batch_v1.create_namespaced_job(
+            body=job,
+            namespace=job_namespace
+        )
+        logging.info(f"Job '{api_response.metadata.name}' created successfully.")
+    except ApiException as e:
+        logging.error(f"Exception when calling BatchV1Api->create_namespaced_job: {e.status} {e.reason}")
+        logging.error(f"Body: {e.body}")
+        raise
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while creating the job: {e}")
+        raise
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch a Kubernetes Job in a target EKS cluster.")
+    parser.add_argument("--target-cluster-name", required=True, help="Name of the target EKS cluster (must match kubeconfig filename).")
+    parser.add_argument("--job-image", required=True, help="Docker image for the Job to be run in the target cluster.")
+    parser.add_argument("--job-namespace", default="default", help="Namespace in the target cluster to launch the Job (default: default).")
+    parser.add_argument("--kubeconfig-base-path", default="/etc/kubeconfigs", help="Base directory where kubeconfig files are mounted (default: /etc/kubeconfigs).")
+
+    args = parser.parse_args()
+
+    try:
+        launch_job_in_cluster(
+            target_cluster_name=args.target_cluster_name,
+            job_image=args.job_image,
+            job_namespace=args.job_namespace,
+            kubeconfig_base_path=args.kubeconfig_base_path
+        )
+        logging.info("Job launch process completed.")
+    except FileNotFoundError as e:
+        logging.error(f"Configuration error: {e}")
+        # Specific exit code for config file not found could be useful
+        exit(1)
+    except ApiException as e:
+        logging.error(f"Kubernetes API error: {e.status} - {e.reason}")
+        exit(1)
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}")
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,3 @@
+kubernetes>=26.0.0
+# Using a recent version of the kubernetes client.
+# Pinning to a major version is a good practice.

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,170 @@
+# Deployment Guide: Remote Job Launcher
+
+This guide explains how to build and deploy the Remote Job Launcher application.
+This application runs as a Deployment in one Kubernetes cluster (Cluster A) and is designed to launch Kubernetes Jobs in another Kubernetes cluster (Cluster B).
+
+## Prerequisites
+
+1.  **Two Kubernetes Clusters:**
+    *   **Cluster A:** Where the Remote Job Launcher will be deployed.
+    *   **Cluster B:** The target cluster where Jobs will be launched. You need kubeconfig access to this cluster.
+2.  **Docker:** Installed locally to build the Docker image.
+3.  **kubectl:** Installed and configured for Cluster A.
+4.  **Docker Registry:** A container registry (like Docker Hub, ECR, GCR, ACR) to push the built image.
+
+## Project Structure
+
+```
+.
+├── app/
+│   ├── Dockerfile
+│   ├── main.py         # Python application logic
+│   └── requirements.txt  # Python dependencies
+├── docs/
+│   └── DEPLOYMENT_GUIDE.md # This file
+├── k8s/
+│   └── cluster-a/
+│       ├── deployment.yaml
+│       ├── rbac.yaml
+│       └── serviceaccount.yaml
+├── LICENSE
+└── README.md
+```
+
+## Build Steps
+
+1.  **Navigate to the Application Directory:**
+    ```bash
+    cd /path/to/your/project/app
+    ```
+
+2.  **Build the Docker Image:**
+    Replace `YOUR_DOCKER_REGISTRY/remote-job-launcher:latest` with your actual image repository and tag.
+    ```bash
+    docker build -t YOUR_DOCKER_REGISTRY/remote-job-launcher:latest .
+    ```
+
+3.  **Push the Docker Image:**
+    ```bash
+    docker push YOUR_DOCKER_REGISTRY/remote-job-launcher:latest
+    ```
+
+## Deployment Steps (Cluster A)
+
+These steps assume you are deploying to the `default` namespace in Cluster A. Adjust the namespace in the YAML files and `kubectl` commands if using a different one.
+
+1.  **Prepare Kubeconfig for Cluster B:**
+    *   You need the kubeconfig file for Cluster B. Let's assume this file is located at `~/.kube/cluster-b.yaml`.
+    *   The application expects the kubeconfig to be available inside a mounted secret volume. The filename inside this volume should match the `--target-cluster-name` argument provided to the application.
+
+2.  **Create a Kubernetes Secret in Cluster A for Cluster B's Kubeconfig:**
+    Let's say you want to target a cluster you'll refer to as `my-target-cluster`. The `--target-cluster-name` argument to your application will be `my-target-cluster`.
+    Create a secret named `target-cluster-kubeconfig` (this name must match `secretName` in `k8s/cluster-a/deployment.yaml` or you'll need to update the deployment manifest).
+    The *key* within the secret data must match the `my-target-cluster` name.
+
+    ```bash
+    kubectl create secret generic target-cluster-kubeconfig \
+      --from-file=my-target-cluster=/path/to/your/cluster-b.yaml \
+      -n default # Or your target namespace in Cluster A
+    ```
+    *   Replace `/path/to/your/cluster-b.yaml` with the actual path to Cluster B's kubeconfig file.
+    *   The key in the secret (`my-target-cluster`) will become the filename inside the `/etc/kubeconfigs/` directory in the pod. The application will look for `/etc/kubeconfigs/my-target-cluster`.
+
+3.  **Update Deployment Manifest:**
+    Open `k8s/cluster-a/deployment.yaml`:
+    *   **Image:** Change `image: YOUR_DOCKER_REGISTRY/remote-job-launcher:latest` to the image you pushed.
+    *   **Args:**
+        *   Modify `--target-cluster-name` to match the key you used in the secret (e.g., `my-target-cluster`).
+        *   Modify `--job-image` to the image you want to run in Cluster B (e.g., `busybox`).
+        *   Modify `--job-namespace` to the namespace in Cluster B where the job should run (e.g., `default` or `target-jobs`).
+    *   **Secret Name:** Ensure `secretName` under `volumes` matches the name of the secret you created (e.g., `target-cluster-kubeconfig`).
+
+    Example snippet from `deployment.yaml` after changes:
+    ```yaml
+    # ...
+    spec:
+      serviceAccountName: remote-job-launcher-sa
+      containers:
+      - name: launcher
+        image: myregistry/myuser/remote-job-launcher:v1.0.0 # YOUR ACTUAL IMAGE
+        args:
+          - "--target-cluster-name"
+          - "my-target-cluster"       # Must match the key in the secret
+          - "--job-image"
+          - "alpine/git"              # Example job image for Cluster B
+          - "--job-namespace"
+          - "batch-processing"        # Namespace in Cluster B
+        volumeMounts:
+        - name: kubeconfigs
+          mountPath: "/etc/kubeconfigs"
+          readOnly: true
+      volumes:
+      - name: kubeconfigs
+        secret:
+          secretName: target-cluster-kubeconfig # Matches the secret created above
+    # ...
+    ```
+
+4.  **Apply Kubernetes Manifests to Cluster A:**
+    Navigate to the root of the project.
+    ```bash
+    kubectl apply -f k8s/cluster-a/serviceaccount.yaml
+    kubectl apply -f k8s/cluster-a/rbac.yaml
+    kubectl apply -f k8s/cluster-a/deployment.yaml
+    ```
+
+5.  **Verify Deployment:**
+    Check the status of the deployment and pods in Cluster A:
+    ```bash
+    kubectl get deployments -n default
+    kubectl get pods -n default -l app=remote-job-launcher
+    ```
+    Check the logs of the launcher pod:
+    ```bash
+    kubectl logs -f <pod-name-of-launcher> -n default
+    ```
+    If everything is configured correctly, the logs should indicate that it's trying to connect to Cluster B and launch the job.
+
+6.  **Verify Job in Cluster B:**
+    Switch your `kubectl` context to Cluster B and check if the job was created:
+    ```bash
+    kubectl get jobs -n <job-namespace-in-cluster-b> # e.g., batch-processing
+    kubectl get pods -n <job-namespace-in-cluster-b> # To see the job's pod
+    kubectl logs -f <job-pod-name-in-cluster-b> -n <job-namespace-in-cluster-b>
+    ```
+
+## Troubleshooting
+
+*   **ImagePullBackOff (Cluster A):** Ensure the Docker image name in `deployment.yaml` is correct and the image is accessible from Cluster A (publicly or with `imagePullSecrets`).
+*   **Error loading kubeconfig (Launcher Pod Logs):**
+    *   Verify the `secretName` in `deployment.yaml` matches the created secret.
+    *   Verify the `--target-cluster-name` arg matches a key within the secret data.
+    *   Check RBAC permissions: `kubectl describe role remote-job-launcher-role -n default` and `kubectl describe rolebinding remote-job-launcher-rb -n default`.
+    *   Ensure the `fsGroup` is set in `deployment.yaml` under `spec.template.spec.securityContext.fsGroup` if the pod user (`appuser`) cannot read the mounted secret files. The `appuser` has UID `1000` in the provided Dockerfile. `fsGroup: 1000` might be needed.
+*   **Connection refused/timeout to Cluster B (Launcher Pod Logs):**
+    *   Ensure the kubeconfig for Cluster B is correct and its API server is accessible from Cluster A's pods. Network policies or firewalls might be an issue.
+*   **Job creation failed (Launcher Pod Logs):**
+    *   The logs should provide details from the Kubernetes API in Cluster B. This could be due to RBAC issues *within Cluster B* (i.e., the identity defined in Cluster B's kubeconfig doesn't have permission to create jobs).
+    *   Ensure the specified `--job-namespace` exists in Cluster B or the identity has permission to create it.
+
+## Multiple Target Clusters
+
+If you need to target multiple clusters (e.g., `cluster-b-dev`, `cluster-b-staging`, `cluster-b-prod`):
+
+1.  **Create a separate kubeconfig secret for each target cluster in Cluster A.**
+    *   `kubectl create secret generic cluster-b-dev-kubeconfig --from-file=cluster-b-dev=/path/to/dev.config`
+    *   `kubectl create secret generic cluster-b-staging-kubeconfig --from-file=cluster-b-staging=/path/to/staging.config`
+2.  **Modify the `deployment.yaml` in Cluster A:**
+    *   You'll need to decide how the launcher pod will access these.
+        *   **Option A (Multiple Volume Mounts):** Mount each secret to a distinct subpath under `/etc/kubeconfigs`. This would require changes to the application logic to select the correct path.
+        *   **Option B (One Secret, Multiple Keys):** Create a single secret with multiple keys, each key being a target cluster name.
+            ```bash
+            kubectl create secret generic all-target-kubeconfigs \
+              --from-file=cluster-b-dev=/path/to/dev.config \
+              --from-file=cluster-b-staging=/path/to/staging.config
+            ```
+            Then mount this `all-target-kubeconfigs` secret. The application `main.py` already expects the filename in `/etc/kubeconfigs/` to be the target cluster name, so this approach works well with the current code. The `deployment.yaml` would mount `all-target-kubeconfigs` to `/etc/kubeconfigs`.
+    *   The RBAC `Role` in Cluster A would need to be updated to grant access to all these secrets or the single combined secret.
+3.  **Run multiple instances of the launcher deployment**, each configured with different arguments to target a specific cluster, or modify the application to loop through targets or accept a list of targets. For simplicity, running separate, uniquely named deployments (or using something like Argo Workflows/Airflow to orchestrate multiple runs with different parameters) is often easier.
+
+This guide provides a comprehensive overview. Adjust paths, names, and configurations to fit your specific environment.

--- a/k8s/cluster-a/deployment.yaml
+++ b/k8s/cluster-a/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: remote-job-launcher
+  namespace: default # Or your preferred namespace in Cluster A
+  labels:
+    app: remote-job-launcher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: remote-job-launcher
+  template:
+    metadata:
+      labels:
+        app: remote-job-launcher
+    spec:
+      serviceAccountName: remote-job-launcher-sa # Specify the service account
+      containers:
+      - name: launcher
+        image: YOUR_DOCKER_REGISTRY/remote-job-launcher:latest # <-- IMPORTANT: Replace with your image URI
+        args:
+          - "--target-cluster-name"
+          - "cluster-b-dev" # Example: name of the kubeconfig file for target cluster
+          - "--job-image"
+          - "busybox" # Example: image for the job in Cluster B
+          - "--job-namespace"
+          - "target-jobs" # Example: namespace in Cluster B for the job
+          # Kubeconfig base path is defaulted in the app to /etc/kubeconfigs
+        volumeMounts:
+        - name: kubeconfigs
+          mountPath: "/etc/kubeconfigs"
+          readOnly: true
+      volumes:
+      - name: kubeconfigs
+        secret:
+          secretName: cluster-b-kubeconfig # Name of the secret containing the kubeconfig for 'cluster-b-dev'
+          # This secret should have a key that matches the --target-cluster-name argument,
+          # e.g., a key named 'cluster-b-dev' whose value is the kubeconfig content.
+          # Example for creating such a secret:
+          # kubectl create secret generic cluster-b-kubeconfig --from-file=cluster-b-dev=/path/to/your/cluster-b-dev.kubeconfig
+
+      # SecurityContext for the pod if needed, e.g. fsGroup to ensure secret mount readability by appuser
+      # securityContext:
+      #   fsGroup: <ID of appuser, typically 1000 or similar if useradd was used as in Dockerfile>
+
+      # If you need to target multiple clusters, you might need multiple secrets
+      # or a single secret with multiple kubeconfig files, and adjust the deployment args accordingly
+      # or modify the application to select from multiple files in the mounted directory.
+      # The current app expects the filename in /etc/kubeconfigs/ to be exactly the value of --target-cluster-name.

--- a/k8s/cluster-a/rbac.yaml
+++ b/k8s/cluster-a/rbac.yaml
@@ -1,0 +1,40 @@
+# This RBAC setup is for Cluster A.
+# It grants the ServiceAccount permissions to read the Secret containing kubeconfigs for Cluster B.
+
+# If the secret 'cluster-b-kubeconfig' is in the same namespace as the deployment:
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: remote-job-launcher-role
+  namespace: default # Must match the namespace of the Deployment and ServiceAccount
+rules:
+- apiGroups: [""] # Core API group
+  resources: ["secrets"]
+  resourceNames: ["cluster-b-kubeconfig"] # Specific secret name
+  verbs: ["get", "watch"] # "watch" might not be strictly necessary but "get" is essential
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: remote-job-launcher-rb
+  namespace: default # Must match the namespace of the Deployment and ServiceAccount
+subjects:
+- kind: ServiceAccount
+  name: remote-job-launcher-sa # Name of the ServiceAccount
+  namespace: default # Namespace of the ServiceAccount
+roleRef:
+  kind: Role
+  name: remote-job-launcher-role # Name of the Role created above
+  apiGroup: rbac.authorization.k8s.io
+
+# Note:
+# If you plan to store kubeconfigs for many target clusters in different secrets,
+# you might want to grant broader access, e.g., to all secrets with a specific label,
+# or list multiple resourceNames.
+# For now, this is specific to a single secret named 'cluster-b-kubeconfig'.
+#
+# If the secret is in a different namespace, you would need a Role and RoleBinding
+# in that namespace, granting access to the ServiceAccount from the deployment's namespace.
+# Or, use a ClusterRole and ClusterRoleBinding if you need cluster-wide access to secrets
+# (though this is less secure and generally not recommended if namespace-specific access is sufficient).

--- a/k8s/cluster-a/serviceaccount.yaml
+++ b/k8s/cluster-a/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: remote-job-launcher-sa
+  namespace: default # Or your preferred namespace in Cluster A
+  labels:
+    app: remote-job-launcher
+# No specific imagePullSecrets or other configurations needed for this basic SA
+# If using IRSA for EKS, you would add annotations here:
+# annotations:
+#   eks.amazonaws.com/role-arn: arn:aws:iam::YOUR_AWS_ACCOUNT_ID:role/RemoteJobLauncherRoleClusterA


### PR DESCRIPTION
This commit introduces a tool to launch Kubernetes Jobs in a target EKS cluster from a deployment running in a source EKS cluster.

Key components:
- Python application (app/main.py) using the Kubernetes Python client.
- Dockerfile (app/Dockerfile) for packaging the application.
- Kubernetes manifests (k8s/cluster-a/) for deploying the launcher:
    - Deployment, ServiceAccount, RBAC (Role, RoleBinding).
- Authentication is handled by mounting kubeconfig files for target clusters as Secrets in Cluster A. The application reads these based on arguments.
- The Job manifest for the target cluster is generated dynamically by the Python app.
- Includes a DEPLOYMENT_GUIDE.md with build and usage instructions.
- Basic logging and error handling are implemented in the Python app.